### PR TITLE
Adding test harness support for Node 4/6/8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,6 @@
 version: 2
-jobs:
-  build:
-    docker:
-      - image: circleci/node
+references: 
+  run_tests: &run_tests
     steps:
       - checkout
       - run: sudo npm install -g yarn semantic-release@12.0.0
@@ -21,7 +19,26 @@ jobs:
       - store_artifacts:
           path: coverage
           prefix: coverage
-      - run: semantic-release
-      - run: yarn docs
+    # Removing this for now while I'm testing workflows.
+    #   - run: semantic-release
+    # Add this in after fan-out.
+    #   - run: yarn docs
       # needs proper NOW setup first
       # - run: yarn docs:publish
+
+jobs:
+  build-node4:
+    docker:
+      - image: circleci/node:4
+    <<: *run_tests
+  build-node6:
+    docker:
+      - image: circleci/node:6
+    <<: *run_tests
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - build-node4
+      - build-node6

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ references:
   run_tests: &run_tests
     steps:
       - checkout
-      - run: sudo npm install -g yarn semantic-release@12.0.0
+      - run: sudo npm install -g yarn
       - run: yarn install
       - run:
           name: test
@@ -19,12 +19,6 @@ references:
       - store_artifacts:
           path: coverage
           prefix: coverage
-    # Removing this for now while I'm testing workflows.
-    #   - run: semantic-release
-    # Add this in after fan-out.
-    #   - run: yarn docs
-      # needs proper NOW setup first
-      # - run: yarn docs:publish
 
 jobs:
   build-node4:
@@ -35,6 +29,19 @@ jobs:
     docker:
       - image: circleci/node:6
     <<: *run_tests
+  build-node8:
+    docker:
+      - image: circleci/node
+    <<: *run_tests
+  release:
+    docker: 
+      - image: circleci/node
+    steps: 
+      - run: sudo npm install -g semantic-release@12.0.0
+      - run: semantic-release
+      - run: yarn docs
+      # needs proper NOW setup first
+      # - run: yarn docs:publish
 
 workflows:
   version: 2
@@ -42,3 +49,9 @@ workflows:
     jobs:
       - build-node4
       - build-node6
+      - build-node8
+      - release:
+        requires: 
+          - build-node4
+          - build-node6
+          - build-node8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ workflows:
       - build-node6
       - build-node8
       - release:
-        requires: 
-          - build-node4
-          - build-node6
-          - build-node8
+          requires: 
+            - build-node4
+            - build-node6
+            - build-node8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,8 +50,8 @@ workflows:
       - build-node4
       - build-node6
       - build-node8
-      - release:
-        requires: 
-          - build-node4
-          - build-node6
-          - build-node8
+      # - release:
+      #   requires: 
+      #     - build-node4
+      #     - build-node6
+      #     - build-node8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,9 @@ jobs:
     docker: 
       - image: circleci/node
     steps: 
-      - run: sudo npm install -g semantic-release@12.0.0
+      - checkout
+      - run: sudo npm install -g yarn semantic-release@12.0.0
+      - run: yarn install
       - run: semantic-release
       - run: yarn docs
       # needs proper NOW setup first
@@ -50,8 +52,8 @@ workflows:
       - build-node4
       - build-node6
       - build-node8
-      # - release:
-      #   requires: 
-      #     - build-node4
-      #     - build-node6
-      #     - build-node8
+      - release:
+        requires: 
+          - build-node4
+          - build-node6
+          - build-node8

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@types/node": "8.5.9",
     "@types/graphql": "0.12.2",
-    "@types/lodash": "4.14.95",
+    "@types/lodash": "4.14.96",
     "ava": "0.24.0",
     "ava-ts": "0.24.0",
     "nyc": "11.4.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@types/node": "8.5.9",
     "@types/graphql": "0.12.1",
-    "@types/lodash": "4.14.94",
+    "@types/lodash": "4.14.95",
     "ava": "0.24.0",
     "ava-ts": "0.24.0",
     "nyc": "11.4.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@types/node": "8.5.9",
     "@types/graphql": "0.12.1",
-    "@types/lodash": "4.14.92",
+    "@types/lodash": "4.14.93",
     "ava": "0.24.0",
     "ava-ts": "0.24.0",
     "nyc": "11.4.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@types/node": "8.5.9",
-    "@types/graphql": "0.12.2",
+    "@types/graphql": "0.12.3",
     "@types/lodash": "4.14.96",
     "ava": "0.24.0",
     "ava-ts": "0.24.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@types/node": "8.5.9",
     "@types/graphql": "0.12.3",
-    "@types/lodash": "4.14.96",
+    "@types/lodash": "4.14.97",
     "ava": "0.25.0",
     "ava-ts": "0.24.0",
     "nyc": "11.4.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "docs:publish": "cp ./now.json ./docs && cd docs && now --public -f && now alias && now rm --yes --safe graphql-import & cd .."
   },
   "devDependencies": {
-    "@types/node": "8.5.8",
+    "@types/node": "8.5.9",
     "@types/graphql": "0.11.8",
     "@types/lodash": "4.14.92",
     "ava": "0.24.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@types/node": "8.5.9",
     "@types/graphql": "0.12.1",
-    "@types/lodash": "4.14.93",
+    "@types/lodash": "4.14.94",
     "ava": "0.24.0",
     "ava-ts": "0.24.0",
     "nyc": "11.4.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@types/node": "8.5.9",
     "@types/graphql": "0.12.3",
     "@types/lodash": "4.14.96",
-    "ava": "0.24.0",
+    "ava": "0.25.0",
     "ava-ts": "0.24.0",
     "nyc": "11.4.1",
     "tap-xunit": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@types/node": "8.5.9",
-    "@types/graphql": "0.12.1",
+    "@types/graphql": "0.12.2",
     "@types/lodash": "4.14.95",
     "ava": "0.24.0",
     "ava-ts": "0.24.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@types/node": "8.5.9",
-    "@types/graphql": "0.11.8",
+    "@types/graphql": "0.12.1",
     "@types/lodash": "4.14.92",
     "ava": "0.24.0",
     "ava-ts": "0.24.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "graphql-import",
   "version": "0.0.0-semantic-release",
+  "engines": {
+    "node": ">=4.0.0"
+  },
   "license": "MIT",
   "repository": "git@github.com:graphcool/graphql-import.git",
   "files": [

--- a/src/definition.ts
+++ b/src/definition.ts
@@ -1,4 +1,4 @@
-import { keyBy, uniqBy } from 'lodash'
+import { keyBy, uniqBy, includes } from 'lodash'
 import {
   DocumentNode,
   TypeDefinitionNode,
@@ -147,7 +147,7 @@ function collectNewTypeDefinitions(
     // collect missing argument input types
     if (
       !definitionPool.some(d => d.name.value === nodeTypeName) &&
-      !builtinTypes.includes(nodeTypeName)
+      !includes(builtinTypes, nodeTypeName)
     ) {
       const argTypeMatch = schemaMap[nodeTypeName]
       if (!argTypeMatch) {
@@ -165,7 +165,7 @@ function collectNewTypeDefinitions(
     const directiveName = directive.name.value
     if (
       !definitionPool.some(d => d.name.value === directiveName) &&
-      !builtinDirectives.includes(directiveName)
+      !includes(builtinDirectives, directiveName)
     ) {
       const directive = schemaMap[directiveName] as DirectiveDefinitionNode
       if (!directive) {


### PR DESCRIPTION
i've noticed while maintaining [eslint-plugin-graphql](https://github.com/apollographql/eslint-plugin-graphql) that updating to use minor versions of [graphql-config](https://github.com/graphcool/graphql-config) hit a couple of snags in Node v4 support, namely the use of `Array.includes` here in `graphql-import`. node v4 is in maintenance LTS until April 30th, 2018, and while support for Node v4 specifically isn't super important to me, i figured if i was already setting up the harness it wouldn't hurt to backport support.

here's another PR in `graphql-config` that enforces support for Node v6.

things of note:
- in the interest of adding support for Node v4/v6/v8, utilize the [workflows](https://circleci.com/docs/2.0/workflows/) feature in CircleCI to make sure we're running tests in these different environments.

