### PR TITLE
Adding babel to deal with compilation

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,17 +29,36 @@
     "sourceMap": true,
     "instrument": true
   },
+  "babel": {
+    "presets": [
+      "@babel/typescript",
+      [
+        "@babel/preset-env",
+        {
+          "useBuiltIns": "usage",
+          "targets": {
+            "node": "4.0.0"
+          }
+        }
+      ]
+    ]
+  },
   "scripts": {
     "prepare": "npm run build",
-    "build": "rm -rf dist && tsc -d",
+    "build": "npm run type-check && babel src --extensions '.ts' --out-dir dist --delete-dir-on-start",
     "testlocal": "npm run build && nyc --reporter lcov --reporter text ava-ts --verbose src/**/*.test.ts",
     "test-only": "npm run build && nyc --reporter lcov ava-ts --verbose src/**/*.test.ts --tap | tap-xunit > ~/reports/ava.xml",
     "test": "tslint src/**/*.ts && npm run test-only",
+    "type-check": "tsc",
     "docs": "typedoc --out docs src/index.ts --hideGenerator --exclude **/*.test.ts",
     "docs:publish": "cp ./now.json ./docs && cd docs && now --public -f && now alias && now rm --yes --safe graphql-import & cd .."
   },
   "devDependencies": {
-    "@types/node": "8.5.8",
+    "@babel/cli": "^7.0.0-beta.38",
+    "@babel/core": "^7.0.0-beta.38",
+    "@babel/plugin-transform-runtime": "^7.0.0-beta.38",
+    "@babel/preset-env": "^7.0.0-beta.38",
+    "@babel/preset-typescript": "^7.0.0-beta.38",
     "@types/graphql": "0.11.8",
     "@types/lodash": "4.14.92",
     "ava": "0.24.0",

--- a/package.json
+++ b/package.json
@@ -41,13 +41,21 @@
           }
         }
       ]
+    ],
+    "plugins": [
+      [
+        "@babel/transform-runtime",
+        {
+          "helpers": false
+        }
+      ]
     ]
   },
   "scripts": {
     "prepare": "npm run build",
-    "build": "npm run type-check && babel src --extensions '.ts' --out-dir dist --delete-dir-on-start",
-    "testlocal": "npm run build && nyc --reporter lcov --reporter text ava-ts --verbose src/**/*.test.ts",
-    "test-only": "npm run build && nyc --reporter lcov ava-ts --verbose src/**/*.test.ts --tap | tap-xunit > ~/reports/ava.xml",
+    "build": "npm run type-check && babel src --extensions '.ts' --source-maps inline --out-dir dist --delete-dir-on-start",
+    "testlocal": "npm run build && nyc --reporter lcov --reporter text ava --verbose dist/**/*.test.js",
+    "test-only": "npm run build && nyc --reporter lcov ava --verbose dist/**/*.test.js --tap | tap-xunit > ~/reports/ava.xml",
     "test": "tslint src/**/*.ts && npm run test-only",
     "type-check": "tsc",
     "docs": "typedoc --out docs src/index.ts --hideGenerator --exclude **/*.test.ts",
@@ -59,6 +67,7 @@
     "@babel/plugin-transform-runtime": "^7.0.0-beta.38",
     "@babel/preset-env": "^7.0.0-beta.38",
     "@babel/preset-typescript": "^7.0.0-beta.38",
+    "@babel/runtime": "^7.0.0-beta.38",
     "@types/graphql": "0.11.8",
     "@types/lodash": "4.14.92",
     "ava": "0.24.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "noEmit": true,
     "target": "es5",
     "moduleResolution": "node",
     "module": "commonjs",


### PR DESCRIPTION
using babel to compile stuff so we can target older environments. have had some issues running tests on compiled output, but maybe this is enough to bump engines in package.json.